### PR TITLE
Updated to reflect RMQ message model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## 1.5.0
+### Changed
+- Bumped the graylog image to 3.3
+- Increased the version of some of the images
+- Updated the services to fall in line with how the offical graylog documentation has them
+- Set the container names explicitly
+- Mounting the /usr/share/graylog/plugin volume explicitly so the jar can be manually built and copied into place
+
+### Added
+- Added some logging
+- Modified the configuration options.  The 'queue' has been removed in favor of an 'exchange'.  This is because the core model in RMQ is "a producer never sends any messages directly to a queue".
+- Added an optional routing_key configuration option.
+- Removed the Configuration check.  This is done within the Graylog library itself so I wasn't sure that it was warranted.
+- Added a mandatory configuration item of 'vhost'.  This will allow connecting to the non-default vhost.
+- Added new configuration options.
+- Increased the logging verbosity
+- Create a dummy channel so that we can validate an exchange exists.  If it doesn't then we'll use the proper channel to create it, otherwise we just move on.
+- Modified the basicPublish to use the routing_key
 
 ## 1.4.1
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 1.5.0
+## 2.0.0
 ### Changed
 - Bumped the graylog image to 3.3
 - Increased the version of some of the images

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN cd /project
 
 RUN mvn package
 
-FROM graylog/graylog:3.0
+FROM graylog/graylog:3.3
 
 COPY --from=build /project/target/original-* /usr/share/graylog/plugin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,31 +3,58 @@ version: '3'
 services:
   mongodb:
     image: mongo:3
+    container_name: mongo
+    networks:
+      - graylog
+
   elasticsearch:
-    image: elasticsearch:6.6.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.10
+    container_name: elasticsearch
     environment:
-      http.host: 0.0.0.0
-      transport.host: localhost
-      network.host: 0.0.0.0
-      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      - http.host=0.0.0.0
+      - transport.host=localhost
+      - network.host=0.0.0.0
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    networks:
+      - graylog
+
   graylog:
-    build: .
+    image: graylog/graylog:3.3
+    container_name: graylog
     environment:
-      GRAYLOG_PASSWORD_SECRET: somepasswordpepper
+      # CHANGE ME (must be at least 16 characters)!
+      - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
       # Password: admin
-      GRAYLOG_ROOT_PASSWORD_SHA2: 8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
-      GRAYLOG_HTTP_BIND_ADDRESS: 0.0.0.0:9000
-      GRAYLOG_HTTP_EXTERNAL_URI: http://0.0.0.0:9000/
+      - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+      - GRAYLOG_HTTP_EXTERNAL_URI=http://127.0.0.1:9000/
+    networks:
+      - graylog
     volumes:
+      - "./dist:/usr/share/graylog/plugin"
       - "./dist:/out-plugin"
-    links:
-      - mongodb:mongo
+    ports:
+      - 9000:9000
+      - 12201:12201
+      - 1514:1514
     depends_on:
       - mongodb
       - elasticsearch
+
   rabbitmq:
     image: rabbitmq:3-management
-    hostname: rabbit
+    container_name: rabbitmq
     environment:
       RABBITMQ_DEFAULT_USER: admin
       RABBITMQ_DEFAULT_PASS: admin
+    ports:
+      - 15672:15672
+    networks:
+      - graylog
+
+networks:
+  graylog:
+    driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.nexylan.graylog.plugins</groupId>
     <artifactId>graylog-rabbitmq</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.nexylan.graylog.plugins</groupId>
     <artifactId>graylog-rabbitmq</artifactId>
-    <version>1.5.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/net/nexylan/graylog/rabbitmq/RabbitMq.java
+++ b/src/main/java/net/nexylan/graylog/rabbitmq/RabbitMq.java
@@ -150,8 +150,9 @@ public class RabbitMq implements MessageOutput{
 
             configurationRequest.addField(new TextField(
                     RABBIT_PASSWORD, "RabbitMQ Password", "guest",
-                    "Password of the rabbitMQ user",
-                    ConfigurationField.Optional.NOT_OPTIONAL)
+                    "Password of the rabbitMQ user.  Default: guest",
+                    ConfigurationField.Optional.NOT_OPTIONAL,
+                    TextField.Attribute.IS_PASSWORD)
             );
 
             configurationRequest.addField(new NumberField(

--- a/src/main/java/net/nexylan/graylog/rabbitmq/senders/RabbitMQSender.java
+++ b/src/main/java/net/nexylan/graylog/rabbitmq/senders/RabbitMQSender.java
@@ -22,11 +22,12 @@ public class RabbitMQSender implements Sender {
     //Queue properties
     private String host;
     private int port;
-    private String queue;
+    private String vhost;
+    private String exchange;
     private String user;
     private String password;
     private int ttl;
-    private boolean durable;
+    private String routing_key;
 
     //Message properties
     private int message_format;
@@ -34,6 +35,7 @@ public class RabbitMQSender implements Sender {
     //RabbitMQ objects
     private Connection connection;
     private Channel channel;
+    private Channel dummy_channel;
     private boolean lock;
     private AMQP.BasicProperties sendProperties;
 
@@ -42,15 +44,16 @@ public class RabbitMQSender implements Sender {
 
     private boolean is_initialized = false;
 
-    public RabbitMQSender(String host, int port, String queue, String user, String password, int ttl, boolean durable, int message_format)
+    public RabbitMQSender(String host, int port, String vhost, String exchange, String user, String password, int ttl, String routing_key, int message_format)
     {
         this.host = host;
         this.port = port;
-        this.queue = queue;
+        this.vhost = vhost;
+        this.exchange = exchange;
         this.user = user;
         this.password = password;
         this.ttl = ttl;
-        this.durable = durable;
+        this.routing_key = routing_key;
         this.message_format = message_format;
 
         initialize();
@@ -68,19 +71,21 @@ public class RabbitMQSender implements Sender {
         factory = new ConnectionFactory();
         factory.setHost(this.host);
         factory.setPort(this.port);
+        factory.setVirtualHost(this.vhost);
         factory.setUsername(this.user);
         factory.setPassword(this.password);
 
         try {
             this.connection = factory.newConnection();
-            LOG.info("[RabbitMQ] Successfully connected to the server.");
+            LOG.info("[RabbitMQ] Successfully connected to vhost " + this.vhost + " on server " + this.host + ":" + this.port);
         } catch (IOException e) {
-            LOG.error("[RabbitMQ] Failed to connect to RabbitMQ Server.");
+            LOG.error("[RabbitMQ] Failed to connect to vhost " + this.vhost + " on server " + this.host + ":" + this.port);
             e.printStackTrace();
         } catch (TimeoutException e) {
             e.printStackTrace();
-            LOG.error("[RabbitMQ] The RabbitMQ Server timed out.");
+            LOG.error("[RabbitMQ] Time out connecting to vhost " + this.vhost + " on server " + this.host + ":" + this.port);
         }
+
         try {
             this.channel = this.connection.createChannel();
             LOG.info("[RabbitMQ] The channel have been successfully created.");
@@ -89,18 +94,42 @@ public class RabbitMQSender implements Sender {
             e.printStackTrace();
         }
 
+        // Attempt to declare the exchange.  If it already exists then capture the exception
         try {
-            this.channel.queueDeclare(this.queue, false, this.durable, false, null);
-            LOG.info("[RabbitMQ] The queue have been successfully created.");
-        } catch (IOException e) {
-            LOG.error("[RabbitMQ] Impossible to declare the queue.");
-            e.printStackTrace();
+            // Create a dummy channel.
+            this.dummy_channel = this.connection.createChannel();
+            this.dummy_channel.exchangeDeclarePassive(this.exchange);
+        } catch (IOException oe) {
+            try {
+                LOG.info("[RabbitMQ] Attempting to declare " + this.exchange + " as a direct, durable exchange (if it doesn't already exist)");
+                this.channel.exchangeDeclare(this.exchange, "direct", true);
+                try {
+                    this.dummy_channel.close();
+                } catch (TimeoutException ie) {
+                    LOG.error("[RabbitMQ] Timeout occurred while closing the channel.");
+                    ie.printStackTrace();
+                }
+            } catch (IOException e) {
+                LOG.error("[RabbitMQ] An error occurred declaring the exchange.");
+                e.printStackTrace();
+            }
+        }
+
+        if (this.routing_key == "") {
+            LOG.info("[RabbitMQ] Routing key was not specified.  Defaulting to an empty value.");
+            this.routing_key = "";
+        } else {
+            LOG.info("[RabbitMQ] Using routing key " + this.routing_key);
         }
 
         AMQP.BasicProperties.Builder builder = new AMQP.BasicProperties.Builder();
 
-        if(this.ttl != -1)
+        if (this.ttl >= 0) {
+            LOG.info("[RabbitMQ] Setting TTL to " + this.ttl);
             builder.expiration(Integer.toString(this.ttl));
+        } else {
+            LOG.info("[RabbitMQ] Disabling TTL");
+        }
 
         this.sendProperties = builder.build();
         this.is_initialized = true;
@@ -113,7 +142,7 @@ public class RabbitMQSender implements Sender {
         try {
             this.channel.close();
         } catch (TimeoutException e) {
-            LOG.error("[RabbitMQ] An error occurred while closing the channel.");
+            LOG.error("[RabbitMQ] Timeout while closing the channel.");
             e.printStackTrace();
         } catch (IOException e) {
             LOG.error("[RabbitMQ] An error occurred.");
@@ -134,10 +163,10 @@ public class RabbitMQSender implements Sender {
         try {
             switch(this.message_format){
                 case 0:
-                    this.channel.basicPublish("", this.queue, this.sendProperties, message.getMessage().getBytes());
+                    this.channel.basicPublish(this.exchange, this.routing_key, this.sendProperties, message.getMessage().getBytes());
                     break;
                 case 1:
-                    this.channel.basicPublish("", this.queue, this.sendProperties, this.formatToJson(message.getFields()).getBytes());
+                    this.channel.basicPublish(this.exchange, this.routing_key, this.sendProperties, this.formatToJson(message.getFields()).getBytes());
                     break;
             }
         } catch (JsonProcessingException exception) {


### PR DESCRIPTION
Related to https://github.com/nexylan/graylog-rabbitmq/issues/12, essentially this PR modifies the way messages are published into RMQ.  The "official" model for publishing messages is that:
> The core idea in the messaging model in RabbitMQ is that the producer never sends any messages directly to a queue. [1]

So I've modified the config to:
a. specify a vhost
b. specify an exchange vs. a queue.

This will allow publishing to a non-default vhost into an exchange.  If the exchange doesn't exist one will be declared (direct, durable).


1. https://www.rabbitmq.com/tutorials/tutorial-three-java.html